### PR TITLE
Conversion to float error?

### DIFF
--- a/pvextractor/gui.py
+++ b/pvextractor/gui.py
@@ -372,7 +372,7 @@ class PVSlicer(object):
         self.pv_slice = extract_pv_slice(self.array, path)
 
         self.ax2.cla()
-        self.ax2.imshow(self.pv_slice, origin='lower', aspect='auto', interpolation='nearest')
+        self.ax2.imshow(self.pv_slice.data, origin='lower', aspect='auto', interpolation='nearest')
 
         self.fig.canvas.draw()
 


### PR DESCRIPTION
The PVSlicer gui fails on my machine:

```
In [1]: from pvextractor.gui import PVSlicer

In [2]: pv = PVSlicer('CMZ_3mm_HCO+.fits')
WARNING: AstropyDeprecationWarning: Config parameter 'enabled_record_valued_keyword_cards' in section [io.fits] of the file '/Users/adam/.astropy/config/astropy.cfg' is deprecated. Use 'enable_record_valued_keyword_cards' in section [io.fits] instead. [astropy.config.configuration]
WARNING: FITSFixedWarning: 'spcfix' made the change 'Changed CTYPE3 from 'VELO-LSR' to 'VOPT', and SPECSYS to 'LSRK''. [astropy.wcs.wcs]
/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/__init__.py:1241: UserWarning:  This call to matplotlib.use() has no effect
because the backend has already been chosen;
matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
or matplotlib.backends is imported for the first time.

  warnings.warn(_use_error_msg)
/Users/adam/repos/pvextractor/pvextractor/gui.py:280: UserWarning: clim not defined and will be determined from the data
  warnings.warn("clim not defined and will be determined from the data")

In [3]: /Users/adam/repos/pvextractor/pvextractor/geometry/path.py:28: RuntimeWarning: invalid value encountered in divide
  cos_theta = (-dx[:-1] * dx[1:] - dy[:-1] * dy[1:]) / (d[:-1] * d[1:])
/Users/adam/repos/pvextractor/pvextractor/geometry/path.py:31: RuntimeWarning: invalid value encountered in divide
  sin_theta = (-dx[:-1] * dy[1:] + dy[:-1] * dx[1:]) / (d[:-1] * d[1:])
|==========================================================================================================================|  20 / 20  (100.00%)        00s
Exception in Tkinter callback
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/lib-tk/Tkinter.py", line 1470, in __call__
    return self.func(*args)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/backends/backend_tkagg.py", line 399, in button_press_event
    FigureCanvasBase.button_press_event(self, x, y, num, dblclick=dblclick, guiEvent=event)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/backend_bases.py", line 1868, in button_press_event
    self.callbacks.process(s, mouseevent)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/cbook.py", line 533, in process
    proxy(*args, **kwargs)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/cbook.py", line 408, in __call__
    return mtd(*args, **kwargs)
  File "/Users/adam/repos/pvextractor/pvextractor/gui.py", line 86, in on_press
    self.callback(self.box)
  File "/Users/adam/repos/pvextractor/pvextractor/gui.py", line 375, in update_pv_slice
    self.ax2.imshow(self.pv_slice, origin='lower', aspect='auto', interpolation='nearest')
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/axes/_axes.py", line 4510, in imshow
    im.set_data(X)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-intel.egg/matplotlib/image.py", line 428, in set_data
    raise TypeError("Image data can not convert to float")
TypeError: Image data can not convert to float
```

This is actually trivial: `pv.pv_slice` is an HDU... fix in progress!
