### PR TITLE
Allow PVSlicer to load a SpectralCube directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ install:
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx=1.2 matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ install:
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx=1.2 matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/pvextractor/tests/test_slicer.py
+++ b/pvextractor/tests/test_slicer.py
@@ -164,4 +164,9 @@ def test_output_wcs(make_data):
 
     reference = fits.header.Header.fromstring(SLICE_HEADER.strip(), sep='\n')
     for key in reference:
-        assert slice_hdu.header[key] == reference[key]
+        try:
+            # for floats, test that they're close because wcsutils is not always
+            # consistent between versions
+            np.testing.assert_almost_equal(slice_hdu.header[key], reference[key])
+        except TypeError:
+            assert slice_hdu.header[key] == reference[key]


### PR DESCRIPTION
The PVSlicer currently only works from a filename and doesn't take advantage of any of `spectral_cube`'s capabilities, including masking.  This PR allows it to use the cube directly.

It mostly works, but I have been getting bugs that I *think* are unrelated in gui testing