### PR TITLE
Fix half-pixel offset for polygon paths and updated unit tests

### DIFF
--- a/pvextractor/geometry/path.py
+++ b/pvextractor/geometry/path.py
@@ -229,11 +229,11 @@ class Path(object):
 
         polygons = []
 
-        x_beg = x_sampled - dx * spacing * 0.5
-        x_end = x_sampled + dx * spacing * 0.5
+        x_beg = x_sampled
+        x_end = x_sampled + dx * spacing
 
-        y_beg = y_sampled - dy * spacing * 0.5
-        y_end = y_sampled + dy * spacing * 0.5
+        y_beg = y_sampled
+        y_end = y_sampled + dy * spacing
 
         if hasattr(self.width, 'unit'):
             scale = get_spatial_scale(wcs)

--- a/pvextractor/tests/test_slicer.py
+++ b/pvextractor/tests/test_slicer.py
@@ -113,25 +113,21 @@ class TestExtraction:
         slice_hdu = extract_pv_slice(data, path, spacing=0.4, order=0)
         assert_allclose(slice_hdu.data[0], np.array([1., 1., 0., 0., 0., 2., 2., 2., np.nan, np.nan]))
 
-
     def test_pv_slice_hdu_line_path_order_3(self, data):
         path = Path([(1., -0.5), (1., 3.5)])
         slice_hdu = extract_pv_slice(data, path, spacing=0.4, order=3)
         assert_allclose(slice_hdu.data[0], np.array([np.nan, 0.9648, 0.4, -0.0368, 0.5622,
                                                      1.6478, 1.9278, np.nan, np.nan, np.nan]))
 
-
     def test_pv_slice_hdu_poly_path(self, data):
         path = Path([(1., -0.5), (1., 3.5)], width=0.001)
         slice_hdu = extract_pv_slice(data, path, spacing=0.4)
-        assert_allclose(slice_hdu.data[0], np.array([1., 1., 1., 0., 0., 1., 2., 2., np.nan, np.nan]))
-
+        assert_allclose(slice_hdu.data[0], np.array([1., 1., 0.5, 0., 0., 2., 2., 2., np.nan, np.nan]))
 
     def test_pv_slice_hdu_line_path_order_0_no_nan(self, data):
         path = Path([(1., -0.5), (1., 3.5)])
         slice_hdu = extract_pv_slice(data, path, spacing=0.4, order=0, respect_nan=False)
         assert_allclose(slice_hdu.data[0], np.array([1., 1., 0., 0., 0., 2., 2., 2., 0., 0.]))
-
 
     def test_pv_slice_hdu_line_path_order_3_no_nan(self, data):
         path = Path([(1., -0.5), (1., 3.5)])
@@ -139,11 +135,10 @@ class TestExtraction:
         assert_allclose(slice_hdu.data[0], np.array([np.nan, 0.9648, 0.4, -0.0368, 0.5622,
                                                      1.6478, 1.9278, 0.975, 0.0542, np.nan]))
 
-
     def test_pv_slice_hdu_poly_path_no_nan(self, data):
         path = Path([(1., -0.5), (1., 3.5)], width=0.001)
         slice_hdu = extract_pv_slice(data, path, spacing=0.4, respect_nan=False)
-        assert_allclose(slice_hdu.data[0], np.array([1., 1., 1., 0., 0., 1., 2., 2., 0., 0.]))
+        assert_allclose(slice_hdu.data[0], np.array([1., 1., 0.5, 0., 0., 2., 2., 1., 0., 0.]))
 
 
 @pytest.mark.parametrize('make_data', (make_test_hdu, make_test_spectralcube, make_test_data_wcs))


### PR DESCRIPTION
I ran into issues with half-pixel offsets, and realized that the way I am setting up the polygons for the path is offset by 0.5 pixels. The example I've fixed in the unit tests used to look like:

![simple](https://cloud.githubusercontent.com/assets/314716/9361912/14cfc814-469e-11e5-8200-ab80271c7387.png)

and now looks like:

![simple_new](https://cloud.githubusercontent.com/assets/314716/9361933/2887e8e6-469e-11e5-8e85-1e9f7a8f1d6f.png)

This is consistent with what is done for interpolation. The interpolation points are at the center of the new polygons.

cc @keflavich 
