### PR TITLE
Use function from Astropy to get frames

### DIFF
--- a/pvextractor/geometry/path.py
+++ b/pvextractor/geometry/path.py
@@ -3,14 +3,13 @@ from __future__ import print_function
 import sys
 
 import numpy as np
+
 from astropy.wcs import WCSSUB_CELESTIAL
+from astropy.wcs.utils import wcs_to_celestial_frame
+from astropy.coordinates import BaseCoordinateFrame
 
-try:
-    from astropy.coordinates import BaseCoordinateFrame
-except ImportError:  # astropy <= 0.3
-    from astropy.coordinates import SphericalCoordinatesBase as BaseCoordinateFrame
+from ..utils.wcs_utils import get_spatial_scale
 
-from ..utils.wcs_utils import get_wcs_system_frame, get_spatial_scale
 
 class Polygon(object):
     def __init__(self, x, y):
@@ -155,16 +154,11 @@ class Path(object):
                 wcs_sky = wcs.sub([WCSSUB_CELESTIAL])
 
                 # Find the astropy name for the coordinates
-                # TODO: return a frame class with Astropy 0.4, since that can
-                # also contain equinox/epoch info.
-                celestial_system = get_wcs_system_frame(wcs_sky)
+                celestial_system = wcs_to_celestial_frame(wcs_sky)
 
                 world_coords = self._coords.transform_to(celestial_system)
 
-                try:
-                    xw, yw = world_coords.spherical.lon.degree, world_coords.spherical.lat.degree
-                except AttributeError:  # astropy <= 0.3
-                    xw, yw = world_coords.lonangle.degree, world_coords.latangle.degree
+                xw, yw = world_coords.spherical.lon.degree, world_coords.spherical.lat.degree
 
                 return list(zip(*wcs_sky.wcs_world2pix(xw, yw, 0)))
 

--- a/pvextractor/utils/wcs_utils.py
+++ b/pvextractor/utils/wcs_utils.py
@@ -71,14 +71,3 @@ def sanitize_wcs(mywcs):
     return mywcs
 
 
-def get_wcs_system_frame(wcs):
-    """TODO: move to astropy.wcs.utils"""
-    ct = wcs.sub([WCSSUB_CELESTIAL]).wcs.ctype
-    if 'GLON' in ct[0]:
-        from astropy.coordinates import Galactic
-        return Galactic
-    elif 'RA' in ct[0]:
-        from astropy.coordinates import ICRS
-        return ICRS
-    else:
-        raise ValueError("Unrecognized coordinate system")


### PR DESCRIPTION
The current function was very simplistic and returned e.g. ICRS instead of FK5, etc which matters for very high-res data. This PR fixes this by using the now existing proper function from Astropy.

I've also removed backward-compatibility fixes for older versions of Astropy, since I think it's ok to now require Astropy 1.0 since this is an important fix.

cc @keflavich 