### PR TITLE
ds9 pvextractor failure

### DIFF
--- a/pvextractor/pvregions.py
+++ b/pvextractor/pvregions.py
@@ -139,8 +139,8 @@ def vector_to_path(vector_region):
     # -dx because we're in the flippy coordsys
     C2 = csystems[vector_region.coord_format](C1.spherical.lon - dx, C1.spherical.lat + dy)
 
-    C = csystems[vector_region.coord_format]([C1.spherical.lon,C2.spherical.lon],
-                                             [C1.spherical.lat,C2.spherical.lat])
+    C = csystems[vector_region.coord_format]([C1.spherical.lon.deg,C2.spherical.lon.deg]*u.deg,
+                                             [C1.spherical.lat.deg,C2.spherical.lat.deg]*u.deg)
 
     p = path.Path(C)
 

--- a/pvextractor/pvregions.py
+++ b/pvextractor/pvregions.py
@@ -137,10 +137,10 @@ def vector_to_path(vector_region):
     C1 = csystems[vector_region.coord_format](x, y)
     dx,dy = length * np.cos(angle), length * np.sin(angle)
     # -dx because we're in the flippy coordsys
-    C2 = csystems[vector_region.coord_format](C1.lonangle - dx, C1.latangle + dy)
+    C2 = csystems[vector_region.coord_format](C1.spherical.lon - dx, C1.spherical.lat + dy)
 
-    C = csystems[vector_region.coord_format]([C1.lonangle,C2.lonangle],
-                                             [C1.latangle,C2.latangle])
+    C = csystems[vector_region.coord_format]([C1.spherical.lon,C2.spherical.lon],
+                                             [C1.spherical.lat,C2.spherical.lat])
 
     p = path.Path(C)
 

--- a/pvextractor/tests/test_slicer.py
+++ b/pvextractor/tests/test_slicer.py
@@ -79,16 +79,18 @@ def make_test_hdu():
     header = fits.header.Header.fromstring(HEADER_STR, sep='\n')
     hdu = fits.PrimaryHDU(header=header)
     import numpy as np
-    hdu.data = np.zeros((1, 5, 4, 3))
-    hdu.data[:, :, 0, :] = 1.
-    hdu.data[:, :, 2, :] = 2.
-    hdu.data[:, :, 3, :] = np.nan
+    hdu.data = np.zeros((1, 5, 4))
+    hdu.data[:, :, 0] = 1.
+    hdu.data[:, :, 2] = 2.
+    hdu.data[:, :, 3] = np.nan
     return hdu
 
 
 def make_test_spectralcube():
     header = fits.header.Header.fromstring(HEADER_STR, sep='\n')
+    assert header['NAXIS']==3
     hdu = make_test_hdu()
+    assert hdu.header['NAXIS']==3
     import spectral_cube.io.fits
     cube = spectral_cube.io.fits.load_fits_cube(hdu)
     assert cube.unit == 'K'

--- a/pvextractor/tests/test_slicer.py
+++ b/pvextractor/tests/test_slicer.py
@@ -10,13 +10,12 @@ from ..geometry.path import Path
 
 # Use a similar header as in the spectral_cube package
 HEADER_STR = """
-SIMPLE  =                    T / Written by IDL:  Fri Feb 20 13:46:36 2009
+SIMPLE  =                    T  /
 BITPIX  =                  -32  /
-NAXIS   =                    4  /
+NAXIS   =                    3  /
 NAXIS1  =                    3  /
 NAXIS2  =                    4  /
 NAXIS3  =                    5  /
-NAXIS4  =                    1  /
 EXTEND  =                    T  /
 BSCALE  =    1.00000000000E+00  /
 BZERO   =    0.00000000000E+00  /
@@ -34,10 +33,6 @@ CDELT3  =    1.28821496879E+03  /
 CRPIX3  =    1.00000000000E+00  /
 CRVAL3  =   -3.21214698632E+05  /
 CTYPE3  = 'VELO-HEL'  /
-CDELT4  =    1.00000000000E+00  /
-CRPIX4  =    1.00000000000E+00  /
-CRVAL4  =    1.00000000000E+00  /
-CTYPE4  = 'STOKES  '  /
 DATE-OBS= '1998-06-18T16:30:25.4'  /
 RESTFREQ=    1.42040571841E+09  /
 CELLSCAL= 'CONSTANT'  /

--- a/pvextractor/tests/test_slicer.py
+++ b/pvextractor/tests/test_slicer.py
@@ -61,7 +61,7 @@ CRPIX2  =                  1.0 / Pixel coordinate of reference point
 CDELT1  =    0.000222222224507 / [deg] Coordinate increment at reference point
 CDELT2  =        1288.21496879 / [m s-1] Coordinate increment at reference point
 CUNIT1  = 'deg'                / Units of coordinate increment and value
-CUNIT2  = 'm s-1'              / Units of coordinate increment and value
+CUNIT2  = 'm/s'                / Units of coordinate increment and value
 CTYPE1  = 'OFFSET'             / Coordinate type code
 CTYPE2  = 'VOPT'               / Optical velocity (linear)
 CRVAL1  =                  0.0 / [deg] Coordinate value at reference point
@@ -79,10 +79,10 @@ def make_test_hdu():
     header = fits.header.Header.fromstring(HEADER_STR, sep='\n')
     hdu = fits.PrimaryHDU(header=header)
     import numpy as np
-    hdu.data = np.zeros((1, 5, 4))
-    hdu.data[:, :, 0] = 1.
-    hdu.data[:, :, 2] = 2.
-    hdu.data[:, :, 3] = np.nan
+    hdu.data = np.zeros((5, 4, 3))
+    hdu.data[:, 0, :] = 1.
+    hdu.data[:, 2, :] = 2.
+    hdu.data[:, 3, :] = np.nan
     return hdu
 
 

--- a/pvextractor/tests/test_wcspath.py
+++ b/pvextractor/tests/test_wcspath.py
@@ -14,8 +14,9 @@ def data_path(filename):
 
 
 @pytest.mark.xfail
-def test_wcspath():
-    p1,p2 = pvregions.paths_from_regfile(data_path('tests.reg'))
+@pytest.mark.parametrize('regfile', ('tests.reg', 'tests_fk5.reg'))
+def test_wcspath(regfile):
+    p1,p2 = pvregions.paths_from_regfile(data_path(regfile))
     w = wcs.WCS(fits.Header.fromtextfile(data_path('w51.hdr')))
     p1.set_wcs(w)
 
@@ -24,3 +25,28 @@ def test_wcspath():
                 226.35546, 100.99054)
     xy = (np.array(zip(shouldbe[::2],shouldbe[1::2])) - 1)
     np.testing.assert_allclose(np.array((p1.xy)), xy, rtol=1e-5)
+
+"""
+TODO:
+    fix this test
+
+/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/numpy/core/function_base.py:115: ValueError
+______________________________________________________________________________________________ test_wcspath[tests.reg] _______________________________________________________________________________________________
+
+regfile = 'tests.reg'
+
+    @pytest.mark.parametrize('regfile', ('tests.reg', 'tests_fk5.reg'))
+    def test_wcspath(regfile):
+>       p1,p2 = pvregions.paths_from_regfile(data_path(regfile))
+E       ValueError: too many values to unpack (expected 2)
+
+pvextractor/tests/test_wcspath.py:18: ValueError
+____________________________________________________________________________________________ test_wcspath[tests_fk5.reg] _____________________________________________________________________________________________
+
+regfile = 'tests_fk5.reg'
+
+    @pytest.mark.parametrize('regfile', ('tests.reg', 'tests_fk5.reg'))
+    def test_wcspath(regfile):
+>       p1,p2 = pvregions.paths_from_regfile(data_path(regfile))
+E       ValueError: too many values to unpack (expected 2)
+"""


### PR DESCRIPTION
With a VLA cube, I get the following traceback:

```
Traceback (most recent call last):
  File "/Users/adam/bin/ds9_pvextract.py", line 4, in <module>
    __import__('pkg_resources').run_script('pvextractor==0.0.dev255', 'ds9_pvextract.py')
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/setuptools-19.1.1-py2.7.egg/pkg_resources/__init__.py", line 745, in run_script

  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/setuptools-19.1.1-py2.7.egg/pkg_resources/__init__.py", line 1670, in run_script

  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/pvextractor-0.0.dev255-py2.7.egg/EGG-INFO/scripts/ds9_pvextract.py", line 44, in <module>
    paths = paths_from_regions(regions)
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/pvextractor-0.0.dev255-py2.7.egg/pvextractor/pvregions.py", line 169, in paths_from_regions
    if r.name in region_converters]
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/pvextractor-0.0.dev255-py2.7.egg/pvextractor/pvregions.py", line 140, in vector_to_path
    C2 = csystems[vector_region.coord_format](C1.lonangle - dx, C1.latangle + dy)
  File "/Users/adam/repos/astropy/astropy/coordinates/baseframe.py", line 1030, in __getattr__
    .format(self.__class__.__name__, attr))
AttributeError: 'FK5' object has no attribute 'lonangle'
```

which seems to indicate that we're using an outdated version of the astropy.coordinates API