### PR TITLE
Test for BaseSpectralCube with _is_spectral_cube

### DIFF
--- a/pvextractor/pvextractor.py
+++ b/pvextractor/pvextractor.py
@@ -109,7 +109,7 @@ def extract_pv_slice(cube, path, wcs=None, spacing=1.0, order=3,
 
 def _is_spectral_cube(obj):
     try:
-        from spectral_cube import SpectralCube
-        return isinstance(obj, SpectralCube)
+        from spectral_cube import BaseSpectralCube
+        return isinstance(obj, BaseSpectralCube)
     except ImportError:
         return False

--- a/pvextractor/pvextractor.py
+++ b/pvextractor/pvextractor.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
+import warnings
 
 from astropy import units as u
 from astropy.extern import six
@@ -112,4 +113,7 @@ def _is_spectral_cube(obj):
         from spectral_cube.spectral_cube import BaseSpectralCube
         return isinstance(obj, BaseSpectralCube)
     except ImportError:
+        if 'SpectralCube' in (obj.__class__):
+            warnings.warn("Object appears to be a SpectralCube, but"
+                          " the spectral_cube module could not be loaded")
         return False

--- a/pvextractor/pvextractor.py
+++ b/pvextractor/pvextractor.py
@@ -109,7 +109,7 @@ def extract_pv_slice(cube, path, wcs=None, spacing=1.0, order=3,
 
 def _is_spectral_cube(obj):
     try:
-        from spectral_cube import BaseSpectralCube
+        from spectral_cube.spectral_cube import BaseSpectralCube
         return isinstance(obj, BaseSpectralCube)
     except ImportError:
         return False


### PR DESCRIPTION
instead of `SpectralCube`, which is a subclass