### PR TITLE
GUI failure: WCS issue

### DIFF
--- a/pvextractor/utils/wcs_slicing.py
+++ b/pvextractor/utils/wcs_slicing.py
@@ -35,6 +35,9 @@ def slice_wcs(wcs, spatial_scale):
     wcs_slice.wcs.cunit[0] = 'deg'
     # Not clear why this is needed, but apparently sub with 0 sets pc[1,0] = 1,
     # which is incorrect
-    wcs_slice.wcs.pc[1,0] = wcs_slice.wcs.pc[0,1] = 0
+    try:
+        wcs_slice.wcs.pc[1,0] = wcs_slice.wcs.pc[0,1] = 0
+    except AttributeError:
+        pass
 
     return wcs_slice


### PR DESCRIPTION
I get the following failure when using the PVSlicer gui:
```
  cos_theta = (-dx[:-1] * dx[1:] - dy[:-1] * dy[1:]) / (d[:-1] * d[1:])
/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/geometry/path.py:30: RuntimeWarning: invalid value encountered in true_divide
  sin_theta = (-dx[:-1] * dy[1:] + dy[:-1] * dx[1:]) / (d[:-1] * d[1:])
|========================================================================================================================================================================================| 367 /367  (100.00%)        19s
Traceback (most recent call last):
  File "/Users/adam/anaconda/envs/astropy36mpl2/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 388, in process
    proxy(*args, **kwargs)
  File "/Users/adam/anaconda/envs/astropy36mpl2/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 228, in __call__
    return mtd(*args, **kwargs)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/gui.py", line 86, in on_press
    self.callback(self.box)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/gui.py", line 376, in update_pv_slice
    self.pv_slice = extract_pv_slice(self.array, path)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/pvextractor.py", line 104, in extract_pv_slice
    header = slice_wcs(wcs, spatial_scale=world_spacing).to_header()
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/utils/wcs_slicing.py", line 38, in slice_wcs
    wcs_slice.wcs.pc[1,0] = wcs_slice.wcs.pc[0,1] = 0
AttributeError: No pc is present.
|========================================================================================================================================================================================| 367 /367  (100.00%)        16s
Traceback (most recent call last):
  File "/Users/adam/anaconda/envs/astropy36mpl2/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 388, in process
    proxy(*args, **kwargs)
  File "/Users/adam/anaconda/envs/astropy36mpl2/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 228, in __call__
    return mtd(*args, **kwargs)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/gui.py", line 86, in on_press
    self.callback(self.box)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/gui.py", line 376, in update_pv_slice
    self.pv_slice = extract_pv_slice(self.array, path)
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/pvextractor.py", line 104, in extract_pv_slice
    header = slice_wcs(wcs, spatial_scale=world_spacing).to_header()
  File "/Users/adam/repos/pvextractor/build/lib.macosx-10.7-x86_64-3.6/pvextractor/utils/wcs_slicing.py", line 38, in slice_wcs
    wcs_slice.wcs.pc[1,0] = wcs_slice.wcs.pc[0,1] = 0
AttributeError: No pc is present.
```

This is a pretty easy fix I think... need to use `get_cd` or something like that...