### PR TITLE
Issue108: URL broken in the example use case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ a series of points and returns a PV array. It is based on scipy’s
 ``map_coordinates`` but also has .
 
 For an example use case, see [this notebook]
-(http://nbviewer.ipython.org/urls/raw.github.com/keflavich/pvextractor/master/examples/IRAS05358Slicing.ipynb)
+(http://nbviewer.ipython.org/urls/raw.github.com/radio-astro-tools/pvextractor/master/examples/IRAS05358Slicing.ipynb)
 (for a permanent, compiled version, look
 `here <examples/IRAS05358Slicing.html>`__)
 

--- a/examples/IRAS05358Slicing.html
+++ b/examples/IRAS05358Slicing.html
@@ -1682,7 +1682,7 @@ In&nbsp;[1]:
 </div>
 <div class="inner_cell">
     <div class="input_area">
-<div class="highlight"><pre><span class="n">url</span> <span class="o">=</span> <span class="s">&#39;http://files.figshare.com/1213488/iras05358_12co21.fits&#39;</span>
+<div class="highlight"><pre><span class="n">url</span> <span class="o">=</span> <span class="s">&#39;https://figshare.com/ndownloader/files/3104171/iras05358_12co21.fits&#39;</span>
 </pre></div>
 
 </div>

--- a/examples/IRAS05358Slicing.ipynb
+++ b/examples/IRAS05358Slicing.ipynb
@@ -12,7 +12,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "url = 'http://files.figshare.com/1213488/iras05358_12co21.fits'"
+      "url = 'https://figshare.com/ndownloader/files/3104171/iras05358_12co21.fits'"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
I have fixed a broken URL in the example IRAS05358Slicing, which was reported in the issue 108.

I have also realised that another URL in the README file was not pointing to the main repository, so I have modified it properly too.