### PR TITLE
CI: add weekly cron test run and switch to PyPI trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
     tags:
     - '*'
   pull_request:
+  schedule:
+    # run every Tuesday at 5am UTC
+    - cron: '0 5 * * 2'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ jobs:
     needs: [build_sdist_and_wheel]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pvextractor
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC)
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -36,5 +41,4 @@ jobs:
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          attestations: true


### PR DESCRIPTION
## Summary
- Add a weekly (Tuesday 5am UTC) scheduled test run to `main.yml`, matching spectral-cube/casa-formats-io — catches dependency drift between pushes/PRs.
- Switch `publish.yml` from token-based PyPI auth (`secrets.pypi_password`) to [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) with `attestations: true`, matching the pattern already in use in spectral-cube/uvcombine.

pvextractor's CI had fallen behind its sibling radio-astro-tools packages on both points.

## ⚠️ Action required before merging/tagging a release
Trusted publishing must be configured for the `pvextractor` PyPI project **before** this is used to cut a release, or the publish step will fail:
1. On https://pypi.org/manage/project/pvextractor/settings/publishing/, add a trusted publisher: owner `radio-astro-tools`, repo `pvextractor`, workflow `publish.yml`, environment `pypi`.
2. The `pypi_password` repo secret can then be removed (no longer used after this change).

## Test plan
- [ ] Confirm the `schedule` trigger appears correctly in the Actions tab after merge.
- [ ] Configure trusted publishing on PyPI (see above) before the next tagged release.
- [ ] Verify a tagged release successfully publishes via OIDC (no password needed).