### PR TITLE
Docs once-over: fix stale links, broken example, typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Position-Velocity Diagram Extractor
 ===================================
 
 Full docs are available
-`here <http://pvextractor.readthedocs.org/en/latest/>`__
+`here <https://pvextractor.readthedocs.io/en/latest/>`__
 
 Tool to slice through data cubes and extract position-velocity (or
 other) slices.
@@ -11,10 +11,10 @@ There are a few `utilities <pvextractor/utils>`__ related to header
 trimming & parsing. Otherwise, there’s one main function,
 `pvextractor <pvextractor/pvextractor.py>`__, that takes a data cube and
 a series of points and returns a PV array. It is based on scipy’s
-``map_coordinates`` but also has .
+``map_coordinates``.
 
 For an example use case, see [this notebook]
-(http://nbviewer.ipython.org/urls/raw.github.com/radio-astro-tools/pvextractor/master/examples/IRAS05358Slicing.ipynb)
+(http://nbviewer.ipython.org/urls/raw.github.com/radio-astro-tools/pvextractor/main/examples/IRAS05358Slicing.ipynb)
 (for a permanent, compiled version, look
 `here <examples/IRAS05358Slicing.html>`__)
 
@@ -24,9 +24,13 @@ Minimal Install Instructions
 
 ::
 
-   pip install https://github.com/ericmandel/pyds9/archive/master.zip
-   pip install https://github.com/radio-astro-tools/spectral-cube/archive/master.zip
-   pip install https://github.com/radio-astro-tools/pvextractor/archive/master.zip
+   pip install pvextractor
+
+To install the latest development version instead::
+
+   pip install https://github.com/ericmandel/pyds9/archive/main.zip
+   pip install https://github.com/radio-astro-tools/spectral-cube/archive/main.zip
+   pip install https://github.com/radio-astro-tools/pvextractor/archive/main.zip
 
 The pvextractor GUI
 -------------------
@@ -65,13 +69,10 @@ Extractor” in the menu.
 
    Example DS9 use
 
-Build and coverage status
-=========================
+Build status
+============
 
-|Coverage Status| |Build Status| |Powered by Astropy|
-
-.. |Coverage Status| image:: https://coveralls.io/repos/radio-astro-tools/pvextractor/badge.svg?branch=master
-   :target: https://coveralls.io/r/radio-astro-tools/pvextractor?branch=master
+|Build Status| |Powered by Astropy|
 
 .. |Build Status| image:: https://github.com/radio-astro-tools/pvextractor/actions/workflows/main.yml/badge.svg
    :target: https://github.com/radio-astro-tools/pvextractor/actions/workflows/main.yml

--- a/docs/ds9.rst
+++ b/docs/ds9.rst
@@ -1,9 +1,11 @@
 Slicing in DS9
 ==============
 
-.. note:: This feature is experimental and does not work with all versions of
-          DS9 at this point. DS9 functionality is also not regularly tested.
-          Please report any issues on `github <https://github.com/radio-astro-tools/pvextractor/issues>`_.
+.. warning:: DS9 integration is no longer actively supported or regularly
+             tested, and may not work with all versions of DS9. It is
+             maintained on a best-effort basis. Please report any issues on
+             `github <https://github.com/radio-astro-tools/pvextractor/issues>`_,
+             but be aware that fixes may not be prioritized.
 
 There is a python command-line script that will be installed into your path
 along with ``pvextractor``.  You can invoke it from the command line, but the

--- a/docs/ds9.rst
+++ b/docs/ds9.rst
@@ -5,8 +5,6 @@ Slicing in DS9
           DS9 at this point. DS9 functionality is also not regularly tested.
           Please report any issues on `github <https://github.com/radio-astro-tools/pvextractor/issues>`_.
 
-.. TODO: be more specific about which DS9 versions are supported
-
 There is a python command-line script that will be installed into your path
 along with ``pvextractor``.  You can invoke it from the command line, but the
 preferred approach is to load the

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -1,7 +1,7 @@
 Using the built-in graphical user interface
 ===========================================
 
-The extractor GUI provdes the most direct interface available to the
+The extractor GUI provides the most direct interface available to the
 pixel-matched version of the position-velocity extractor.  It is simple to
 initialize:
 

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -10,6 +10,8 @@ PV data:
 .. code-block:: python
 
    import pylab as pl
+   from astropy import wcs
+   from astropy import units as u
    from spectral_cube import SpectralCube
    from pvextractor import extract_pv_slice, Path
 

--- a/docs/programmatic.rst
+++ b/docs/programmatic.rst
@@ -33,7 +33,7 @@ World coordinates
 ^^^^^^^^^^^^^^^^^
 
 To define a path in world coordinates, pass a coordinate array to the ``Path``
-object.   In addition, the width (if passed) should an Astropy
+object.   In addition, the width (if passed) should be an Astropy
 :class:`~astropy.units.Quantity` object::
 
     >>> from astropy import units as u
@@ -41,7 +41,7 @@ object.   In addition, the width (if passed) should an Astropy
     >>> g = Galactic([3.4, 3.6] * u.deg, [0.5, 0.56] * u.deg)
     >>> path4 = Path(g, width=1 * u.arcsec)
 
-In additon to the :class:`~pvextractor.Path` class, we provide a convenience
+In addition to the :class:`~pvextractor.Path` class, we provide a convenience
 :class:`~pvextractor.PathFromCenter` class that can be used for cases where the
 center and position angle of the path are known (rather than the end points of
 the path). This class is used as follows:


### PR DESCRIPTION
## Summary
Addresses the "once-over of the text" part of #126 (the DS9 experimental-feature warning was already added in #130, now upgraded further below).

- **docs/ds9.rst**: upgraded the note into a `.. warning::` stating DS9 integration is no longer actively supported/regularly tested and is maintained on a best-effort basis.
- **README.rst**: replace dead `master`-branch install/notebook links with `main`, add a normal `pip install pvextractor` as the primary install instruction (the archive/zip commands were the *only* install instructions given, which is misleading), drop the Coveralls badge (no coveralls/codecov config exists anywhere in CI, so it's stale/dead), point the docs link at `readthedocs.io` instead of the old `readthedocs.org` URL, and fix two broken sentences ("but also has ." / stray wording).
- **docs/plotting.rst**: the WCS-plotting example referenced `wcs.WCS(...)` and `u.arcmin`/`u.km` without importing `astropy.wcs`/`astropy.units` — copy-pasting the snippet raised `NameError`.
- **docs/gui.rst**, **docs/programmatic.rst**: typo fixes ("provdes" → "provides", "should an Astropy" → "should be an Astropy", "additon" → "addition").

## Test plan
- [ ] Docs build cleanly (`sphinx-build -b html . _build/html` from `docs/`, or check RTD build on this PR).
- [ ] Spot-check the plotting.rst snippet runs end-to-end with the added imports.